### PR TITLE
Now the useBinder hook can accept multiples events or just one 🔥

### DIFF
--- a/react-18/client/hooks/index.ts
+++ b/react-18/client/hooks/index.ts
@@ -12,13 +12,13 @@ import * as React from "react";
    const bindEvents : string[] = typeof events === 'string' ? [events] : events;
     React.useEffect(() => {
         objects.forEach(object => {
-            if(!object?.bind) return
-            bindEvents.forEach(event => object.bind(event, onBinder));
+            if(!object?.on) return
+            bindEvents.forEach(event => object.on(event, onBinder));
         });
        
         return () => objects.forEach(object => {
-            if(!object?.unbind) return
-            bindEvents.forEach(event => object.unbind(event, onBinder));
+            if(!object?.off) return
+            bindEvents.forEach(event => object.off(event, onBinder));
         });
     }, []);
 }

--- a/react-18/client/hooks/index.ts
+++ b/react-18/client/hooks/index.ts
@@ -1,5 +1,4 @@
-import * as React from 'react';
-
+import * as React from "react";
 /***
  * Executes a useEffect hook binging the event defined in all
  * objects passed
@@ -8,13 +7,18 @@ import * as React from 'react';
  * @param {function} onBinder function to be executed when the event is fired
  * @param {string} event the event to be listened, by default is event change
  */
-export /*bundle*/
-function useBinder(objects: any[], onBinder: () => void, event: string = 'change'): void {
-    React.useEffect((): (() => void) => {
-        objects.forEach((object: any): void => {
-            if (!object) throw new Error(`object is not valid in useBinder ${object}`);
-            object.on(event, onBinder);
+ export /*bundle*/
+ function useBinder(objects: any[], onBinder: () => void, events: string | string[] = 'change'): void {
+   const bindEvents : string[] = typeof events === 'string' ? [events] : events;
+    React.useEffect(() => {
+        objects.forEach(object => {
+            if(!object?.bind) return
+            bindEvents.forEach(event => object.bind(event, onBinder));
         });
-        return (): void => objects.forEach((object: any) => object.off(event, onBinder));
+       
+        return () => objects.forEach(object => {
+            if(!object?.unbind) return
+            bindEvents.forEach(event => object.unbind(event, onBinder));
+        });
     }, []);
 }


### PR DESCRIPTION
# Why?
One of the main features and the reason for the existence of the usebinder is to be able to listen to events of reactive objects... But what happens when we need to listen to more than one? Would we copy the same binder but changing the event that listens? It does not seem a good option, this change in the hook allows to receive an array of events to listen to be able to define which we want to take into account and it does not break the previous logic since it continues being able to receive a single event in a simple string 🏆!